### PR TITLE
feat(db): use "strict" when creating tables

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,26 +1,26 @@
 create table groups (
-    id varchar(21) primary key not null,
-    name varchar(255) not null
-);
+    id TEXT primary key,
+    name TEXT not null
+) strict;
 
 create table wishlists (
-    id varchar(21) primary key not null,
-    admin_id varchar(21) not null,
-    user_id varchar(21) references users (id),
-    name varchar(255) not null,
-    group_id varchar(21) references groups (id)
-);
+    id TEXT primary key,
+    admin_id TEXT not null,
+    user_id TEXT references users (id),
+    name TEXT not null,
+    group_id TEXT references groups (id)
+) strict;
 
 create table wishlist_elements (
-    id varchar(21) primary key not null,
-    wishlist_id varchar(21) not null references wishlists (id),
-    name varchar(255) not null,
+    id TEXT primary key,
+    wishlist_id TEXT not null references wishlists (id),
+    name TEXT not null,
     description text,
-    url varchar(2048)
-);
+    url TEXT
+) strict;
 
 create table users (
-    id varchar(21) primary key not null,
-    name varchar(255) not null,
-    email varchar(255)
-);
+    id TEXT primary key,
+    name TEXT not null,
+    email TEXT
+) strict;


### PR DESCRIPTION
SQLite by default does not enforce types nor not null primary keys. I love SQLIte but this sucks. Using the "strict" keyword makes it behaves as you would expect from an SQL database.

Note that there is no `varchar` type in SQLite, just `text`.